### PR TITLE
Set your plugins to runtime

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -18,7 +18,7 @@ grails.project.dependency.resolution = {
             export = false
         }
 
-        compile ':karman-aws:0.3.1'
-        compile ':asset-pipeline:1.6.2'
+        runtime ':karman-aws:0.3.1'
+        runtime ':asset-pipeline:1.6.2'
     }
 }


### PR DESCRIPTION
Set asset-pipeline and karman to runtime. This means that if unspecified by app, it will use your runtime dependency versions. Otherwise it will prefer their apps version.
